### PR TITLE
Add Nix flake + install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Mkfile.old
 dkms.conf
 
 .vscode/
+result

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Install/uninstall it using your favorite AUR helper.
 #### OpenSUSE (Open Build Service)
 This project is in the OBS under [activate-linux](https://software.opensuse.org//download.html?project=home%3AWoMspace&package=activate-linux).
 
+### Nix (NixOS)
+This repository is a flake. Run it using `nix run "github:MrGlockenspiel/activate-linux"`.
+
 #### Other
 
 You can use `make install` to install and `make uninstall` to remove it.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1652840887,
+        "narHash": "sha256-gEK4NNa4GwIgTZE63kt/4WTFAWRTJVSa30+h4ZjFh9U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "52dc75a4fee3fdbcb792cb6fba009876b912bfe0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "The \"Activate Windows\" watermark ported to Linux";
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      packages.activate-linux = pkgs.stdenv.mkDerivation {
+        name = "activate-linux";
+        src = pkgs.lib.cleanSource ./.;
+
+        makeFlags = [
+          "PREFIX=/"
+          "DESTDIR=${placeholder "out"}"
+          "CC=${pkgs.stdenv.cc}/bin/cc"
+        ];
+
+        buildInputs = with pkgs; [
+          pkg-config
+
+          cairo
+          xorg.libXi
+          xorg.libX11
+          xorg.xorgproto
+          xorg.libXt
+          xorg.libXfixes
+          xorg.libXinerama
+        ];
+      };
+
+      packages.default = self.packages.${system}.activate-linux;
+    });
+}


### PR DESCRIPTION
Add `flake.nix` to allow this to be installed using [nix](https://nixos.org).

---

For the purposes of #79, if this is merged first;

I, Sciencentistguy, agree to activate-linux being relicensed under the GPLv3 license