### PR TITLE
Uninstall Removes Correct File

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install: $(BINARY)
 	install -Dm0755 $(BINARY) $(DESTDIR)$(PREFIX)/$(BINDIR)/$(BINARY)
 
 uninstall:
-	$(RM) -f $(DESTDIR)$(PREFIX)$(BINDIR)/$(BINARY)
+	$(RM) -f $(DESTDIR)$(PREFIX)/$(BINDIR)/$(BINARY)
 
 clean:
 	$(RM) -f $(BINARY)


### PR DESCRIPTION
remove /usr/local/bin/activate-linux not /usr/localbin/activate-linux