### PR TITLE
Added the options to set the overlay width and height

### DIFF
--- a/src/activate_linux.c
+++ b/src/activate_linux.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[]) {
     bool daemonize = false;
 
     int opt;
-    while ((opt = getopt(argc, argv, "h?vbwdit:m:f:s:c:H:V:W:")) != -1) {
+    while ((opt = getopt(argc, argv, "h?vbwdit:m:f:s:c:H:V:x:y:")) != -1) {
         switch (opt) {
             case 'v':
                 verbose_mode = true;
@@ -158,8 +158,11 @@ int main(int argc, char *argv[]) {
             case 'V':
                 offset_top = atoi(optarg);
                 break;
-            case 'W':
+            case 'x':
                 overlay_width = atoi(optarg);
+                break;
+            case 'y':
+                overlay_height = atoi(optarg);
                 break;
             case '?':
             case 'h':
@@ -184,7 +187,8 @@ int main(int argc, char *argv[]) {
                 HELP("-s scale\tScale ratio (float)");
                 HELP("-H offset\tMove overlay horizontally (integer)");
                 HELP("-V offset\tMove overlay  vertically  (integer)");
-                HELP("-W width\tSet overlay width");
+                HELP("-x width\tSet overlay width before scaling (integer)");
+                HELP("-y height\tSet overlay height before scaling (integer)");
                 HELP("-v\t\tBe verbose and spam console");
                 #undef HELP
                 #undef STYLE

--- a/src/activate_linux.c
+++ b/src/activate_linux.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[]) {
     bool daemonize = false;
 
     int opt;
-    while ((opt = getopt(argc, argv, "h?vbwdit:m:f:s:c:H:V:")) != -1) {
+    while ((opt = getopt(argc, argv, "h?vbwdit:m:f:s:c:H:V:W:")) != -1) {
         switch (opt) {
             case 'v':
                 verbose_mode = true;
@@ -158,6 +158,9 @@ int main(int argc, char *argv[]) {
             case 'V':
                 offset_top = atoi(optarg);
                 break;
+            case 'W':
+                overlay_width = atoi(optarg);
+                break;
             case '?':
             case 'h':
                 #define HELP(X) fprintf(stderr, "  " X "\n")
@@ -181,6 +184,7 @@ int main(int argc, char *argv[]) {
                 HELP("-s scale\tScale ratio (float)");
                 HELP("-H offset\tMove overlay horizontally (integer)");
                 HELP("-V offset\tMove overlay  vertically  (integer)");
+                HELP("-W width\tSet overlay width");
                 HELP("-v\t\tBe verbose and spam console");
                 #undef HELP
                 #undef STYLE


### PR DESCRIPTION
The text gets clipped if it's too long, and there are no options to change the overlay width.

I have added two options, `-x <width>` and `-y <height>`, that allow to change the overlay size. `W` and `H` would have been better options but `H` was already taken.

### Before resizing
![Not_resized](https://user-images.githubusercontent.com/39098990/173233339-a8695dad-60ad-4824-9d43-6ea8ebac98bb.png)

### After resizing
![resized](https://user-images.githubusercontent.com/39098990/173233338-974e3d92-fba4-40df-b82c-452ae6834215.png)
