### PR TITLE
rpm spec: add Wayland requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ emerge --sync vaacus
 emerge -av activate-linux
 ```
 
-### openSUSE / SLE
+#### openSUSE / SLE
 The package is built for various releases on
 [OBS](https://build.opensuse.org/package/show/home:tschmitz:activate-linux/activate-linux).
 
@@ -78,7 +78,7 @@ zypper refresh
 zypper install activate-linux
 ```
 
-### Fedora
+#### Fedora
 The package is built for various releases on
 [OBS](https://build.opensuse.org/package/show/home:tschmitz:activate-linux/activate-linux).
 

--- a/activate-linux.spec
+++ b/activate-linux.spec
@@ -7,7 +7,9 @@ Group: System/GUI/Other
 Source: activate-linux-%{version}.tar.gz
 URL: https://github.com/MrGlockenspiel/activate-linux
 Buildroot: /tmp/activate-linux-git
-BuildRequires: clang cairo-devel libXi-devel libX11-devel libXrandr-devel libXt-devel libXinerama-devel
+BuildRequires: clang cairo-devel
+BuildRequires: libXi-devel libX11-devel libXrandr-devel libXt-devel libXinerama-devel
+BuildRequires: wayland-devel
 
 %if 0%{?suse_version}
 BuildRequires: xcb-proto-devel

--- a/activate-linux.spec
+++ b/activate-linux.spec
@@ -1,5 +1,5 @@
 Summary: The "Activate Windows" watermark ported to Linux
-Version: 0
+Version: 0.2
 License: GPL-3.0-only
 Name: activate-linux
 Release: 1


### PR DESCRIPTION
Since Wayland is now a build requirement given how the Makefile is written, I added it as a Requirement.

Builds on both openSUSE TW and Fedora but breaks on Leap. Seems to be an issue in `wlr-layer-shell-unstable-v1.h`.
See the build output: https://build.opensuse.org/build/home:tschmitz:activate-linux/15.3/x86_64/activate-linux/_log

But that is a separate issue worthy of a second PR.