### PR TITLE
Prevent the nix flake using sudo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,18 @@
           gawk
           pkg-config
         ] ++ (import ./deps.nix {inherit pkgs;});
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/bin
+          mkdir -p $out/share/man/man1
+
+          cp activate-linux $out/bin
+          cp activate-linux.1 $out/share/man/man1
+
+          runHook postInstall
+        '';
       };
 
       packages.default = self.packages.${system}.activate-linux;


### PR DESCRIPTION
- Nix's build environment doesn't have sudo
- The default install command here used sudo
- This commit adds a custom nix build phase to prevent the use of sudo

---

Without this commit we get this beautiful error when building on nixos:

```
{21:05}~/Code/c-cpp/activate-linux:main ✓ ➭ nix run "github:MrGlockenspiel/activate-linux"
error: builder for '/nix/store/rb7b11n9z18b2kwdrglr6hlax432r5r5-activate-linux.drv' failed with exit code 2;
       last 10 log lines:
       >  GEN	x11/XEventTypes.c
       >   CC	x11/XEventTypes.c
       > LINK	activate_linux.o cairo_draw_text.o color.o config.o i18n.o log.o options.o wayland/wayland.o x11/x11.o wayland/wlr-layer-shell-unstable-v1.o wayland/xdg-shell.o x11/XEventTypes.o
       > rm src/wayland/wlr-layer-shell-unstable-v1.c src/wayland/wlr-layer-shell-unstable-v1.h src/x11/XEventTypes.c src/wayland/xdg-shell.c
       > glibPreInstallPhase
       > installing
       > install flags: SHELL=/nix/store/14lypyys4gfcl982rjddxa6jg7msqz9q-bash-5.1-p16/bin/bash PREFIX=/ DESTDIR=/nix/store/q13adhfads3y7gz7cfd9mv6r5x9zbn3y-activate-linux CC=/nix/store/gfr4ljdlr1wplc01j4fchw4w9x3lfvv9-gcc-wrapper-11.3.0/bin/cc gsettingsschemadir=/nix/store/q13adhfads3y7gz7cfd9mv6r5x9zbn3y-activate-linux/share/gsettings-schemas/activate-linux/glib-2.0/schemas/ install
       > sudo install -Dm0755 activate-linux /nix/store/q13adhfads3y7gz7cfd9mv6r5x9zbn3y-activate-linux//bin/activate-linux
       > /nix/store/14lypyys4gfcl982rjddxa6jg7msqz9q-bash-5.1-p16/bin/bash: line 1: sudo: command not found
       > make: *** [Makefile:118: install] Error 127
       For full logs, run 'nix log /nix/store/rb7b11n9z18b2kwdrglr6hlax432r5r5-activate-linux.drv'.
```

---

With this commit, everything appears to work properly