### PR TITLE
make: Implement optional deps support

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1,5 +1,3 @@
-#ifdef LIBCONFIG
-
 #include <libconfig.h>
 #include "log.h"
 #include "options.h"
@@ -122,5 +120,3 @@ void load_config(const char *const file) {
 
   config_destroy(cf);
 }
-
-#endif


### PR DESCRIPTION
Implements:
 * Selectively rebuild when previous buildenv had an optional dependency
   that the current buildenv doesn't have.
 * Allow enabling/disabling optional features.
 * Remove source implementing optional feature from targets
   (fixes compiler warning when an optional dependency is not found)

Signed-off-by: Mubashshir <ahmubashshir@gmail.com>
