### PR TITLE
[CI] Cutting edge actions

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: speedup dpkg
         run: sudo sh -c "echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/force-unsafe-io"

--- a/.github/workflows/obs-tarball.yml
+++ b/.github/workflows/obs-tarball.yml
@@ -19,7 +19,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -14,7 +14,7 @@ jobs:
           - {chain: mingw64, cc: gcc}
           - {chain: clang64, cc: clang}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.chain}}
@@ -26,8 +26,18 @@ jobs:
           export BINARY=activate-windows-${{matrix.chain}}.exe
           make
       - name: Upload .exe
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
+        with:
+          name: activate-windows-${{matrix.chain}}
+          path: activate-windows-${{matrix.chain}}.exe
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Merge *.exe
+        uses: actions/upload-artifact/merge@v4
         with:
           name: activate-windows.exe
-          path: |
-            activate-windows-*.exe
+          pattern: activate-windows-*
+          delete-merged: true
+          compression-level: 9


### PR DESCRIPTION
GitHub now [barking on old actions](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).