### PR TITLE
Fixed fr_FR translation and added french canadian translation

### DIFF
--- a/src/i18n.c
+++ b/src/i18n.c
@@ -13,7 +13,7 @@
 #endif
 
 
-// Compare 5 fist chars from strings
+// Compare 5 first chars from strings
 #define match_str(match, with) (match && with && (strncmp(match, with, 5) == 0))
 // Length of array
 #define length(array) (sizeof(array) / sizeof(array[0]))
@@ -33,7 +33,9 @@ i18n_info_soup langs[] = {
     {"No hay necesidad de activar ", "", "No somos tan molestos como Microsoft."}},
   {"de_DE", {"", " aktivieren", "Wechseln Sie zu den Einstellungen, um ", " zu aktivieren."},
     {"", " muss nicht aktiviert werden", "Wir sind nicht so lästig wie Microsoft."}},
-  {"fr_FR", {"Activer ", "", "Aller en les paramètres pour activer ", "."},
+  {"fr_CA", {"Activez ", "", "Accédez aux paramètres pour activer ", "."},
+    {"Pas besoin d'activer", "", "Nous ne sommes pas aussi gossants que Microsoft."}},
+  {"fr_FR", {"Activez ", "", "Accédez aux paramètres pour activer ", "."},
     {"Pas besoin d'activer", "", "Nous ne sommes pas aussi agaçants que Microsoft."}},
   {"it_IT", {"Attiva ", "", "Passa a Impostazioni per attivare ", "."},
     {NULL, NULL, NULL}},


### PR DESCRIPTION
The french translation wasn't correct. I googled the actual french Activate Windows message to make sure I had it perfect.
![2024-04-09_22:29:35](https://github.com/MrGlockenspiel/activate-linux/assets/20406191/8d8aadb2-76a5-48bf-a4dd-13e06d9f4d8e)

The diss looked fine, but I added a french canadian version that is going to feel more natural to us.
