### PR TITLE
Remove offsets

### DIFF
--- a/ARGS.md
+++ b/ARGS.md
@@ -58,6 +58,8 @@ Default color is `1-1-1-0.35` (dimmed white)
 
 ## Size and position
 
+Note that message always appears in the top left corner of the overlay.
+
 ### Custom overlay width
 ```console
 # Default width = 340px
@@ -76,24 +78,6 @@ Default color is `1-1-1-0.35` (dimmed white)
 ```console
 ./activate-linux -s 1.5
 ./activate-linux --scale 1.5
-```
-
-### Move overlay horizontally
-```console
-# 42 pixels left
-./activate-linux -H 42
-# 42 pixels right
-./activate-linux -H -42
-./activate-linux --overlay-offset-left -42
-```
-
-### Move overlay vertically
-```console
-# 42 pixels bottom
-./activate-linux -V 42
-# 42 pixels up
-./activate-linux -V -42
-./activate-linux --overlay-offset-top -42
 ```
 
 ## Other

--- a/src/config.c
+++ b/src/config.c
@@ -86,14 +86,6 @@ void load_config(const char *const file) {
     options.overlay_height = itmp;
   }
 
-  if (config_lookup_int(cf, "overlay-offset-top", &itmp) != CONFIG_FALSE) {
-    options.offset_top = itmp;
-  }
-
-  if (config_lookup_int(cf, "overlay-offset-left", &itmp) != CONFIG_FALSE) {
-    options.offset_left = itmp;
-  }
-
   if (config_lookup_bool(cf, "daemonize", &itmp) != CONFIG_FALSE) {
     options.daemonize = (bool)itmp;
   }

--- a/src/options.c
+++ b/src/options.c
@@ -68,8 +68,6 @@ void parse_options(int argc, char *const argv[]) {
     {"overlay-width",       required_argument, NULL, 'x'},
     {"overlay-height",      required_argument, NULL, 'y'},
     {"scale",               required_argument, NULL, 's'},
-    {"overlay-offset-left", required_argument, NULL, 'H'},
-    {"overlay-offset-top",  required_argument, NULL, 'V'},
     // other
     {"bypass-compositor",   no_argument,       NULL, 'w'},
     {"daemonize",           no_argument,       NULL, 'd'},
@@ -89,7 +87,7 @@ void parse_options(int argc, char *const argv[]) {
   };
 
   int opt;
-  while ((opt = getopt_long(argc, argv, "t:m:p:f:bic:x:y:s:H:V:wdKvlqGh"
+  while ((opt = getopt_long(argc, argv, "t:m:p:f:bic:x:y:s:wdKvlqGh"
 #ifdef X11
       "S"
 #endif
@@ -110,8 +108,6 @@ void parse_options(int argc, char *const argv[]) {
       // size and position
       case 'x': options.overlay_width = atoi(optarg); break;
       case 'y': options.overlay_height = atoi(optarg); break;
-      case 'H': options.offset_left = atoi(optarg); break;
-      case 'V': options.offset_top = atoi(optarg); break;
       // other
       case 'w': options.bypass_compositor = true; break;
       case 'd': options.daemonize = true; break;
@@ -128,7 +124,7 @@ void parse_options(int argc, char *const argv[]) {
       case 's':
         options.scale = atof(optarg);
         if (options.scale < 0.0f) {
-          __error__("Cannot parse custom scale value. It must be number from 0.0 to 1.0\n");
+          __error__("Cannot parse custom scale value. It must be number greater than 0.0.\n");
           exit(EXIT_FAILURE);
         }
         break;
@@ -196,8 +192,6 @@ void print_help(const char *const file_name) {
   HELP("-x, --overlay-width width \tSet overlay width  before scaling (integer)");
   HELP("-y, --overlay-height height \tSet overlay height before scaling (integer)");
   HELP("-s, --scale scale \t\tScale ratio (float)");
-  HELP("-H, --overlay-offset-left offset \tMove overlay horizontally (integer)");
-  HELP("-V, --overlay-offset-top offset \tMove overlay  vertically  (integer)");
   END();
 
   SECTION("Other", "");

--- a/src/options.c
+++ b/src/options.c
@@ -26,8 +26,6 @@ Options options = {
   // overlay position
   .overlay_width = 340,
   .overlay_height = 120,
-  .offset_left = 0,
-  .offset_top = 0,
 
   // default color is light grey, which has enough contrast to be noticed
   // on both light and dark background.

--- a/src/options.h
+++ b/src/options.h
@@ -17,8 +17,6 @@ typedef struct options_t {
 
   int overlay_width;
   int overlay_height;
-  int offset_left;
-  int offset_top;
 
   rgba_color text_color;
 

--- a/src/wayland/wayland.c
+++ b/src/wayland/wayland.c
@@ -244,8 +244,8 @@ static void output_done(void *data, struct wl_output *wl_output)
                                          ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT);
         zwlr_layer_surface_v1_set_exclusive_zone(output->layer_surface, -1);
         zwlr_layer_surface_v1_set_margin(output->layer_surface,
-                                         0, options.offset_top,
-                                         0, options.offset_left);
+                                         0, 0,
+                                         0, 0);
         zwlr_layer_surface_v1_add_listener(output->layer_surface,
                                            &layer_surface_listener, output);
         wl_surface_commit(output->surface);

--- a/src/x11/x11.c
+++ b/src/x11/x11.c
@@ -119,8 +119,8 @@ int x11_backend_start(void)
         __debug__("Creating overlay on %d screen\n", i);
         overlay[i] = XCreateWindow(d,                                                                // display
                                    root,                                                             // parent
-                                   si[i].x_org + si[i].width + options.offset_left - overlay_width,  // x position
-                                   si[i].y_org + si[i].height + options.offset_top - overlay_height, // y position
+                                   si[i].x_org + si[i].width - overlay_width,  // x position
+                                   si[i].y_org + si[i].height - overlay_height, // y position
                                    overlay_width,                                                    // width
                                    overlay_height,                                                   // height
                                    0,                                                                // border width
@@ -201,8 +201,8 @@ int x11_backend_start(void)
                     __debug__("  Moving window on screen %d according new position\n", i);
                     XMoveWindow(d,                                                               // display
                                 overlay[i],                                                      // window
-                                si[i].x_org + si[i].width + options.offset_left - overlay_width, // x position
-                                si[i].y_org + si[i].height + options.offset_top - overlay_height // y position
+                                si[i].x_org + si[i].width - overlay_width, // x position
+                                si[i].y_org + si[i].height - overlay_height // y position
                     );
                 }
             }


### PR DESCRIPTION
Remove the -H and -V flags and related code. These flags were meant to move the overlay, however they do not work. The -x and -y flags accomplish the same goal anyways, so having broken flags that are not really needed seems like it could confuse users.

This solves my issue #214 