### PR TITLE
Fix crash on Wayland due to uninitialised variable

### DIFF
--- a/src/wayland/wayland.c
+++ b/src/wayland/wayland.c
@@ -317,7 +317,7 @@ static const struct wl_registry_listener registry_listener = {
 
 int wayland_backend_start(void)
 {
-    struct state state;
+    struct state state = {0};
 
     wl_list_init(&state.outputs);
 


### PR DESCRIPTION
Valgrind output:
```
==321663== Conditional jump or move depends on uninitialised value(s)
==321663==    at 0x10B178: UnknownInlinedFun (wayland.c:335)
==321663==    by 0x10B178: main (activate_linux.c:85)
```
<details>

<summary>Full output</summary>

```
$ valgrind activate-linux -vvv
==321663== Memcheck, a memory error detector
==321663== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==321663== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==321663== Command: activate-linux -vvv
==321663== 
Current verbosity level: WARN
Current verbosity level: INFO
Current verbosity level: DEBUG
INFO:  Starting backend
DEBUG: Hadling wayland global: wl_compositor
DEBUG: Hadling wayland global: wl_drm
DEBUG: Hadling wayland global: wl_shm
DEBUG: Hadling wayland global: zxdg_output_manager_v1
DEBUG: Hadling wayland global: wl_data_device_manager
DEBUG: Hadling wayland global: zwp_primary_selection_device_manager_v1
DEBUG: Hadling wayland global: wl_subcompositor
DEBUG: Hadling wayland global: xdg_wm_base
DEBUG: Hadling wayland global: gtk_shell1
DEBUG: Hadling wayland global: wp_viewporter
DEBUG: Hadling wayland global: wp_fractional_scale_manager_v1
DEBUG: Hadling wayland global: zwp_pointer_gestures_v1
DEBUG: Hadling wayland global: zwp_tablet_manager_v2
DEBUG: Hadling wayland global: wl_seat
DEBUG: Hadling wayland global: zwp_relative_pointer_manager_v1
DEBUG: Hadling wayland global: zwp_pointer_constraints_v1
DEBUG: Hadling wayland global: zxdg_exporter_v2
DEBUG: Hadling wayland global: zxdg_importer_v2
DEBUG: Hadling wayland global: zxdg_exporter_v1
DEBUG: Hadling wayland global: zxdg_importer_v1
DEBUG: Hadling wayland global: zwp_linux_dmabuf_v1
DEBUG: Hadling wayland global: wp_single_pixel_buffer_manager_v1
DEBUG: Hadling wayland global: zwp_keyboard_shortcuts_inhibit_manager_v1
DEBUG: Hadling wayland global: zwp_text_input_manager_v3
DEBUG: Hadling wayland global: wp_presentation
DEBUG: Hadling wayland global: xdg_activation_v1
DEBUG: Hadling wayland global: zwp_idle_inhibit_manager_v1
DEBUG: Hadling wayland global: wp_linux_drm_syncobj_manager_v1
DEBUG: Hadling wayland global: xdg_wm_dialog_v1
DEBUG: Hadling wayland global: wp_drm_lease_device_v1
DEBUG: Hadling wayland global: wp_drm_lease_device_v1
DEBUG: Hadling wayland global: wl_output
DEBUG: Hadling wayland global: wl_output
==321663== Conditional jump or move depends on uninitialised value(s)
==321663==    at 0x10B178: UnknownInlinedFun (wayland.c:335)
==321663==    by 0x10B178: main (activate_linux.c:85)
==321663== 
==321663== Use of uninitialised value of size 8
==321663==    at 0x4A07D24: wl_proxy_get_version (wayland-client.c:2317)
==321663==    by 0x10D1C3: UnknownInlinedFun (wlr-layer-shell-unstable-v1.h:229)
==321663==    by 0x10D1C3: output_done (wayland.c:235)
==321663==    by 0x4D7B975: ffi_call_unix64 (unix64.S:104)
==321663==    by 0x4D7812B: ffi_call_int.lto_priv.0 (ffi64.c:676)
==321663==    by 0x4D7AF0D: ffi_call (ffi64.c:713)
==321663==    by 0x4A078AF: wl_closure_invoke.constprop.0 (connection.c:1228)
==321663==    by 0x4A08138: dispatch_event (wayland-client.c:1674)
==321663==    by 0x4A08552: UnknownInlinedFun (wayland-client.c:1820)
==321663==    by 0x4A08552: wl_display_dispatch_queue_pending (wayland-client.c:2062)
==321663==    by 0x10B189: UnknownInlinedFun (wayland.c:341)
==321663==    by 0x10B189: main (activate_linux.c:85)
==321663== 
==321663== Use of uninitialised value of size 8
==321663==    at 0x4A0B34C: wl_proxy_marshal_flags (wayland-client.c:853)
==321663==    by 0x10D1ED: UnknownInlinedFun (wlr-layer-shell-unstable-v1.h:229)
==321663==    by 0x10D1ED: output_done (wayland.c:235)
==321663==    by 0x4D7B975: ffi_call_unix64 (unix64.S:104)
==321663==    by 0x4D7812B: ffi_call_int.lto_priv.0 (ffi64.c:676)
==321663==    by 0x4D7AF0D: ffi_call (ffi64.c:713)
==321663==    by 0x4A078AF: wl_closure_invoke.constprop.0 (connection.c:1228)
==321663==    by 0x4A08138: dispatch_event (wayland-client.c:1674)
==321663==    by 0x4A08552: UnknownInlinedFun (wayland-client.c:1820)
==321663==    by 0x4A08552: wl_display_dispatch_queue_pending (wayland-client.c:2062)
==321663==    by 0x10B189: UnknownInlinedFun (wayland.c:341)
==321663==    by 0x10B189: main (activate_linux.c:85)
==321663== 
==321663== Invalid read of size 8
==321663==    at 0x4A0B36F: wl_proxy_marshal_flags (wayland-client.c:853)
==321663==    by 0x10D1ED: UnknownInlinedFun (wlr-layer-shell-unstable-v1.h:229)
==321663==    by 0x10D1ED: output_done (wayland.c:235)
==321663==    by 0x4D7B975: ffi_call_unix64 (unix64.S:104)
==321663==    by 0x4D7812B: ffi_call_int.lto_priv.0 (ffi64.c:676)
==321663==    by 0x4D7AF0D: ffi_call (ffi64.c:713)
==321663==    by 0x4A078AF: wl_closure_invoke.constprop.0 (connection.c:1228)
==321663==    by 0x4A08138: dispatch_event (wayland-client.c:1674)
==321663==    by 0x4A08552: UnknownInlinedFun (wayland-client.c:1820)
==321663==    by 0x4A08552: wl_display_dispatch_queue_pending (wayland-client.c:2062)
==321663==    by 0x10B189: UnknownInlinedFun (wayland.c:341)
==321663==    by 0x10B189: main (activate_linux.c:85)
==321663==  Address 0x2b3c8042d975c095 is not stack'd, malloc'd or (recently) free'd
==321663== 
==321663== 
==321663== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==321663==  General Protection Fault
==321663==    at 0x4A0B36F: wl_proxy_marshal_flags (wayland-client.c:853)
==321663==    by 0x10D1ED: UnknownInlinedFun (wlr-layer-shell-unstable-v1.h:229)
==321663==    by 0x10D1ED: output_done (wayland.c:235)
==321663==    by 0x4D7B975: ffi_call_unix64 (unix64.S:104)
==321663==    by 0x4D7812B: ffi_call_int.lto_priv.0 (ffi64.c:676)
==321663==    by 0x4D7AF0D: ffi_call (ffi64.c:713)
==321663==    by 0x4A078AF: wl_closure_invoke.constprop.0 (connection.c:1228)
==321663==    by 0x4A08138: dispatch_event (wayland-client.c:1674)
==321663==    by 0x4A08552: UnknownInlinedFun (wayland-client.c:1820)
==321663==    by 0x4A08552: wl_display_dispatch_queue_pending (wayland-client.c:2062)
==321663==    by 0x10B189: UnknownInlinedFun (wayland.c:341)
==321663==    by 0x10B189: main (activate_linux.c:85)
==321663== 
==321663== HEAP SUMMARY:
==321663==     in use at exit: 50,544 bytes in 41 blocks
==321663==   total heap usage: 122 allocs, 81 frees, 66,376 bytes allocated
==321663== 
==321663== LEAK SUMMARY:
==321663==    definitely lost: 0 bytes in 0 blocks
==321663==    indirectly lost: 0 bytes in 0 blocks
==321663==      possibly lost: 928 bytes in 4 blocks
==321663==    still reachable: 49,616 bytes in 37 blocks
==321663==         suppressed: 0 bytes in 0 blocks
==321663== Rerun with --leak-check=full to see details of leaked memory
==321663== 
==321663== Use --track-origins=yes to see where uninitialised values come from
==321663== For lists of detected and suppressed errors, rerun with: -s
==321663== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```

</details>
