### PR TITLE
nix: add pango to dependencies

### DIFF
--- a/deps.nix
+++ b/deps.nix
@@ -1,6 +1,7 @@
 { pkgs }:
 with pkgs; [
 	cairo
+	pango
 	xorg.libXi
 	xorg.libX11
 	xorg.xorgproto


### PR DESCRIPTION
otherwise fails to find `pango/pangocairo.h`:
```
CC     cairo_draw_text.c
src/cairo_draw_text.c:6:10: fatal error: pango/pangocairo.h: No such file or directory
    6 | #include <pango/pangocairo.h>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:131: obj/cairo_draw_text.o] Error 1
```
