### PR TITLE
nix: flake updates and minor packaging improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652840887,
-        "narHash": "sha256-gEK4NNa4GwIgTZE63kt/4WTFAWRTJVSa30+h4ZjFh9U=",
+        "lastModified": 1753432016,
+        "narHash": "sha256-cnL5WWn/xkZoyH/03NNUS7QgW5vI7D1i74g48qplCvg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52dc75a4fee3fdbcb792cb6fba009876b912bfe0",
+        "rev": "6027c30c8e9810896b92429f0092f624f7b1aace",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,8 @@
         name = "activate-linux";
         src = pkgs.lib.cleanSource ./.;
 
+        meta.mainProgram = "activate-linux";
+
         makeFlags = [
           "PREFIX=/"
           "DESTDIR=${placeholder "out"}"

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,10 @@
           pkg-config
         ] ++ (import ./deps.nix {inherit pkgs;});
 
+        nativeBuildInputs = with pkgs; [
+          wayland-scanner
+        ];
+
         installPhase = ''
           runHook preInstall
 


### PR DESCRIPTION
Trying to build with the latest unstable NixOS nixpkgs branch (when using the this repository's flake as an input to another flake, with a different flake.lock) produced an error, most likely due this change: https://github.com/NixOS/nixpkgs/pull/214906

I also decided to update the flake's dependencies to a newer version, and mark the main executable in the package.