### PR TITLE
Fix lang detection error caused by lang hint

### DIFF
--- a/src/i18n.c
+++ b/src/i18n.c
@@ -150,7 +150,10 @@ bool match_lang_two_letter_code(const char *lang_code, const char *lang) {
         i++;
         break;
       }
-
+      if (lang_code[i] == '.') {
+        break;
+      }
+      
       if (failed) {
         i++;
         continue;


### PR DESCRIPTION
"cs_CZ.UTF-8" was getting flagged as unsupported even though "cs_CZ" is supported

added skip after lang hint dot