### PR TITLE
Add Irish language locale to the list of translations

### DIFF
--- a/src/i18n.c
+++ b/src/i18n.c
@@ -27,7 +27,7 @@ i18n_info_soup langs[] = {
 //   {"Diss title prefix", "Diss title suffix", "Subtitle with Microsoft diss"}},
 
 // English is default language, so it has to be first in the list
-  {"en_US,en_GB,en_CA", {"Activate ", "", "Go to Settings to activate ", "."},
+  {"en_US,en_GB,en_CA,en_IE", {"Activate ", "", "Go to Settings to activate ", "."},
     {"No need to activate ", "", "We're not as annoying as Microsoft."}},
   {"ca_ES,ca_AD,ca_FR,ca_IT", 
     {"Activeu ", "", "Aneu a configuració per activar ", "."},


### PR DESCRIPTION
```
ERROR: activate-linux lacks translation for `en_IE.UTF-8' language. You are welcome to fix this :3
ERROR: Using English translation
```

Adding this to the list of locales fixes the above error