### PR TITLE
Read Distro name from /etc/os-release

### DIFF
--- a/ARGS.md
+++ b/ARGS.md
@@ -29,6 +29,12 @@ Color is formatted in "r-g-b-a", with each number being a decimal from 0 to 1. D
 ./activate-linux --text-preset "bsd"
 ```
 
+### Use Distro name
+```console
+./activate-linux -o
+./activate-linux --os-release
+```
+
 ## Appearance
 
 ### Custom Font

--- a/src/i18n.c
+++ b/src/i18n.c
@@ -1,6 +1,9 @@
 #include "i18n.h"
 #include "options.h"
 #include "log.h"
+#ifdef __linux__
+  #include "osrelease.h"
+#endif
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -266,10 +269,20 @@ void i18n_set_info(const char *const preset) {
     strcat(options.subtitle, langs[lang_id].diss.subtitle);
   } else {
     strcat(options.title, langs[lang_id].windows_like.pre_title);
+#ifdef __linux__
+    if (options.osrelease)
+      strcat(options.title, get_release_info());
+    else
+#endif
     strcat(options.title, presets[preset_id].text);
     strcat(options.title, langs[lang_id].windows_like.post_title);
 
     strcat(options.subtitle, langs[lang_id].windows_like.pre_subtitle);
+#ifdef __linux__
+    if (options.osrelease)
+      strcat(options.subtitle, get_release_info());
+    else
+#endif
     strcat(options.subtitle, presets[preset_id].text);
     strcat(options.subtitle, langs[lang_id].windows_like.post_subtitle);
   }

--- a/src/options.c
+++ b/src/options.c
@@ -42,6 +42,10 @@ Options options = {
 
   // kill running instance of activate-linux
   .kill_running = false,
+#ifdef __linux__
+  // read /etc/os-release for exact Distro
+  .osrelease = false,
+#endif
 #ifdef X11
       .force_xshape = false,
 #endif
@@ -74,6 +78,9 @@ void parse_options(int argc, char *const argv[]) {
     {"text-preset-list",    no_argument,       NULL, 'l'},
     {"quiet",               no_argument,       NULL, 'q'},
     {"gamescope",           no_argument,       NULL, 'G'},
+#ifdef __linux__
+    {"os-release",          no_argument,       NULL, 'o'},
+#endif
 #ifdef X11
     {"force-xshape",           no_argument,       NULL, 'S'},
 #endif
@@ -85,7 +92,11 @@ void parse_options(int argc, char *const argv[]) {
   };
 
   int opt;
+
   while ((opt = getopt_long(argc, argv, "t:m:p:f:bic:x:y:s:wdKvlqGh"
+#ifdef __linux__
+      "o"
+#endif
 #ifdef X11
       "S"
 #endif
@@ -113,6 +124,9 @@ void parse_options(int argc, char *const argv[]) {
       case 'v': inc_verbose(); break;
       case 'q': set_silent(); break;
       case 'G': options.gamescope_overlay = true; break;
+#ifdef __linux__
+      case 'o': options.osrelease = true; i18n_set_info("linux"); break;
+#endif
 #ifdef LIBCONFIG
       case 'C': load_config(optarg); break;
 #endif
@@ -172,6 +186,7 @@ void print_help(const char *const file_name) {
   HELP("-m, --text-message message\tSet message text (string)");
   HELP("-p, --text-preset preset\tSelect predefined preset (conflicts "
       "-t/-m)");
+  HELP("-o, --os-release\t\tUse Distro name from /etc/os-release");
   END();
 
   SECTION("Appearance", "");

--- a/src/options.h
+++ b/src/options.h
@@ -24,6 +24,9 @@ typedef struct options_t {
   bool gamescope_overlay;
   bool daemonize;
   bool kill_running;
+#ifdef __linux__
+  bool osrelease;
+#endif
 #ifdef X11
   bool force_xshape;
 #endif

--- a/src/osrelease.c
+++ b/src/osrelease.c
@@ -1,0 +1,61 @@
+#include "options.h"
+#include "log.h"
+#include "osrelease.h"
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+char *get_release_info()
+{
+    const char *PRETTY="PRETTY_NAME";
+    const char *SIMPLE="NAME";
+
+    FILE* osrelease;
+
+    char *line, *pretty, *fallback;
+    size_t size;
+    ssize_t nread;
+    line=NULL;
+
+    __debug__("Attempting to read /etc/os-release\n");
+    if((osrelease=fopen("/etc/os-release","r"))==NULL) {
+        __error__("Error reading /etc/os-release: %s\n", strerror(errno));
+        exit(1);
+    }
+
+    pretty = (char*)malloc(sizeof(char)*1024);
+    memset(pretty, 0, 1024);
+    fallback = (char*)malloc(sizeof(char)*1024);
+    memset(fallback, 0, 1024);
+
+    while((nread=getline(&line, &size, osrelease))!=-1) {
+        if(strncmp(PRETTY, line, strlen(PRETTY))==0)
+            copy_value(PRETTY, line, pretty);
+        if(strncmp(SIMPLE, line, strlen(SIMPLE))==0)
+            copy_value(SIMPLE, line, fallback);
+    }
+    free(line);
+
+    if(pretty[0]==0)
+        return fallback;
+    else
+        return pretty;
+}
+
+void copy_value(const char *var, char *line, char *dest)
+{
+    size_t i;
+    int j=0;
+    char *buffer;
+
+    buffer=strstr(line,"=")+1;
+    for(i=0; i<(strlen(line)-strlen(var)); i++) {
+        if(buffer[i]=='"')
+            continue;
+        if(buffer[i]=='\n')
+            continue;
+        dest[j++]=buffer[i];
+    }
+    dest[j]=0;
+}

--- a/src/osrelease.h
+++ b/src/osrelease.h
@@ -1,0 +1,2 @@
+char *get_release_info();
+void copy_value(const char*, char*, char*);


### PR DESCRIPTION
* Reads the Distro name from /etc/os-release
* Code paths only compiled on Linux
* As requested in #240 hidden behind new option
* Explanation in `ARGS.md`

Not tested on BSD, macOS, Windows since I don't have any of those systems available.